### PR TITLE
feat(data360): migrate extractors and pre-ingestion from chatbot

### DIFF
--- a/.changeset/migrate-data360-extractors.md
+++ b/.changeset/migrate-data360-extractors.md
@@ -1,5 +1,0 @@
----
-"@pcn-js/data360": patch
----
-
-Migrate custom claim extractors, compact output type definitions, and PreIngestSessionClaims layout component from the data-ai-chatbot codebase.

--- a/.changeset/migrate-data360-extractors.md
+++ b/.changeset/migrate-data360-extractors.md
@@ -1,0 +1,5 @@
+---
+"@pcn-js/data360": patch
+---
+
+Migrate custom claim extractors, compact output type definitions, and PreIngestSessionClaims layout component from the data-ai-chatbot codebase.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ secrets/
 
 # OS files
 Thumbs.db
+
+# pnpm store cache
+.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ Thumbs.db
 
 # pnpm store cache
 .pnpm-store/
+
+# Local agent/IDE directories
+.agents/
+.gemini/

--- a/examples/chat-app/CHANGELOG.md
+++ b/examples/chat-app/CHANGELOG.md
@@ -12,10 +12,11 @@
 
 ### Patch Changes
 
-- Updated dependencies
+- Updated dependencies [e49c75c]
   - @pcn-js/core@0.1.2
   - @pcn-js/data360@0.1.2
   - @pcn-js/ui@0.1.2
+
 
 ## 0.0.2
 

--- a/packages/data360/CHANGELOG.md
+++ b/packages/data360/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pcn-js/data360
 
+## 0.1.3
+
+### Patch Changes
+
+- e49c75c: Migrate custom claim extractors, compact output type definitions, and PreIngestSessionClaims layout component from the data-ai-chatbot codebase.
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/data360/package.json
+++ b/packages/data360/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcn-js/data360",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PCN preset for Data360 get_data: ClaimsProvider + extractor for claim_id/OBS_VALUE/REF_AREA/TIME_PERIOD.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/data360/src/data360-claims-provider.tsx
+++ b/packages/data360/src/data360-claims-provider.tsx
@@ -7,6 +7,7 @@ import {
   type DataPointExtractorOptions,
 } from "@pcn-js/core";
 import { ClaimsProvider } from "@pcn-js/ui";
+import { claimsManager as defaultClaimsManager } from "./ingest-session-data360";
 
 /** Default tool name for Data360 get_data (use with IngestToolOutput). */
 export const DATA360_GET_DATA_TOOL = "data360_get_data";
@@ -31,27 +32,22 @@ export type Data360ClaimsProviderProps = {
  * ClaimsProvider preconfigured with a ClaimsManager and a Data360 get_data
  * data-point extractor. Use with IngestToolOutput (from @pcn-js/ui) when rendering
  * data360_get_data results so ClaimMark can resolve claims by claim_id.
- *
- * @example
- * import { Data360ClaimsProvider, DATA360_GET_DATA_TOOL } from "@pcn-js/data360";
- * import { IngestToolOutput } from "@pcn-js/ui";
- *
- * <Data360ClaimsProvider>
- *   <App />
- * </Data360ClaimsProvider>
- *
- * <IngestToolOutput toolName={DATA360_GET_DATA_TOOL} output={toolPart.output}>
- *   <GetData output={toolPart.output} />
- * </IngestToolOutput>
  */
 export function Data360ClaimsProvider({
-  toolName = DATA360_GET_DATA_TOOL,
-  extractorOptions = DEFAULT_EXTRACTOR_OPTIONS,
+  toolName,
+  extractorOptions,
   children,
 }: Data360ClaimsProviderProps) {
   const manager = useMemo(() => {
+    // If no custom options are provided, use the global pre-configured claimsManager
+    if (!toolName && !extractorOptions) {
+      return defaultClaimsManager;
+    }
+
     const m = new ClaimsManager();
-    m.registerExtractor(toolName, createDataPointExtractor(extractorOptions));
+    const tName = toolName ?? DATA360_GET_DATA_TOOL;
+    const opts = extractorOptions ?? DEFAULT_EXTRACTOR_OPTIONS;
+    m.registerExtractor(tName, createDataPointExtractor(opts));
     return m;
   }, [toolName, extractorOptions]);
 

--- a/packages/data360/src/data360-claims-provider.tsx
+++ b/packages/data360/src/data360-claims-provider.tsx
@@ -7,10 +7,10 @@ import {
   type DataPointExtractorOptions,
 } from "@pcn-js/core";
 import { ClaimsProvider } from "@pcn-js/ui";
-import { claimsManager as defaultClaimsManager } from "./ingest-session-data360";
+import { createData360ClaimsManager } from "./ingest-session-data360";
+import { DATA360_GET_DATA_TOOL } from "./types";
 
-/** Default tool name for Data360 get_data (use with IngestToolOutput). */
-export const DATA360_GET_DATA_TOOL = "data360_get_data";
+export { DATA360_GET_DATA_TOOL };
 
 const DEFAULT_EXTRACTOR_OPTIONS: DataPointExtractorOptions = {
   dataKey: "data",
@@ -39,15 +39,12 @@ export function Data360ClaimsProvider({
   children,
 }: Data360ClaimsProviderProps) {
   const manager = useMemo(() => {
-    // If no custom options are provided, use the global pre-configured claimsManager
-    if (!toolName && !extractorOptions) {
-      return defaultClaimsManager;
+    const m = createData360ClaimsManager();
+    if (toolName || extractorOptions) {
+      const tName = toolName ?? DATA360_GET_DATA_TOOL;
+      const opts = extractorOptions ?? DEFAULT_EXTRACTOR_OPTIONS;
+      m.registerExtractor(tName, createDataPointExtractor(opts));
     }
-
-    const m = new ClaimsManager();
-    const tName = toolName ?? DATA360_GET_DATA_TOOL;
-    const opts = extractorOptions ?? DEFAULT_EXTRACTOR_OPTIONS;
-    m.registerExtractor(tName, createDataPointExtractor(opts));
     return m;
   }, [toolName, extractorOptions]);
 

--- a/packages/data360/src/extractors.ts
+++ b/packages/data360/src/extractors.ts
@@ -1,0 +1,184 @@
+import type { ClaimEntry, ToolResultExtractor } from "@pcn-js/core";
+import type {
+  CompactRankingOutput,
+  CompactComparisonOutput,
+  CompactTimeSeries,
+  CompactSummaryOutput,
+} from "./types";
+
+function parseOutput<T>(output: unknown): T | null {
+  if (output === null || output === undefined) return null;
+  if (typeof output === "string") {
+    try {
+      return JSON.parse(output) as T;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof output === "object") return output as T;
+  return null;
+}
+
+/**
+ * Extractor for data360_rank_countries compact output.
+ * Registers { id: claim_id, claim: { value } } for every entry in rankings[].
+ */
+export const rankCountriesExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactRankingOutput>(output);
+  if (!data?.rankings) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const entry of data.rankings) {
+    if (entry.claim_id && entry.value !== undefined && entry.value !== null) {
+      entries.push({
+        id: entry.claim_id,
+        claim: { value: entry.value, country: entry.code },
+      });
+    }
+  }
+  return entries;
+};
+
+/**
+ * Extractor for data360_compare_countries compact output.
+ * Registers claim_ids from both the snapshot rankings and time-series entries.
+ *
+ * Time series uses positional arrays: series_schema defines the column order,
+ * defaulting to ["time_period", "obs_value", "claim_id"]. We read column
+ * indices from series_schema — never hard-code offsets.
+ */
+export const compareCountriesExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactComparisonOutput>(output);
+  if (!data) return [];
+
+  const entries: ClaimEntry[] = [];
+
+  // Snapshot rankings — same shape as rank_countries entries
+  if (data.snapshot?.rankings) {
+    for (const entry of data.snapshot.rankings) {
+      if (entry.claim_id && entry.value !== undefined && entry.value !== null) {
+        entries.push({
+          id: entry.claim_id,
+          claim: { value: entry.value, country: entry.code, date: data.snapshot.year },
+        });
+      }
+    }
+  }
+
+  // Time-series — positional arrays keyed by country code
+  const ts = data.time_series as CompactTimeSeries | null | undefined;
+  if (ts?.series) {
+    const schema = ts.series_schema ?? ["time_period", "obs_value", "claim_id"];
+    const colValue = schema.indexOf("obs_value");
+    const colClaim = schema.indexOf("claim_id");
+    const colYear = schema.indexOf("time_period");
+
+    for (const [countryCode, points] of Object.entries(ts.series)) {
+      if (!Array.isArray(points)) continue;
+      for (const pt of points) {
+        if (!Array.isArray(pt)) continue;
+        const claimId = colClaim >= 0 ? (pt[colClaim] as string | null) : null;
+        const value = colValue >= 0 ? (pt[colValue] as number | null) : null;
+        const year = colYear >= 0 ? String(pt[colYear] ?? "") : undefined;
+        if (claimId && value !== null && value !== undefined) {
+          entries.push({
+            id: claimId,
+            claim: { value, country: countryCode, date: year },
+          });
+        }
+      }
+    }
+  }
+
+  return entries;
+};
+
+/**
+ * Extractor for data360_summarize_data compact output.
+ *
+ * The compact format only exposes per-observation values for two data points:
+ *   - group.earliest → claim_ids[0]  (chronologically first observation)
+ *   - group.latest   → claim_ids[-1] (chronologically last observation)
+ *
+ * All intermediate claim_ids in between map to observations whose values are
+ * not present in the compact payload. Per the Writer prompt rule, those IDs
+ * should never appear in prose — so we do not register them here.
+ */
+export const summarizeDataExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactSummaryOutput>(output);
+  if (!data?.groups) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const group of data.groups) {
+    if (!group.claim_ids || group.claim_ids.length === 0) continue;
+
+    const groupKeys = Object.entries(group.group ?? {});
+    const refArea = groupKeys.find(([k]) => k === "ref_area")?.[1] ?? undefined;
+
+    const ids = group.claim_ids;
+    const earliestId = ids[0];
+    const latestId = ids[ids.length - 1];
+
+    // Register earliest observation
+    if (
+      earliestId &&
+      group.earliest?.value !== null &&
+      group.earliest?.value !== undefined
+    ) {
+      entries.push({
+        id: earliestId,
+        claim: {
+          value: group.earliest.value,
+          country: refArea,
+          date: group.earliest.year ?? undefined,
+        },
+      });
+    }
+
+    // Register latest observation (only if it's a different ID from earliest)
+    if (
+      latestId &&
+      latestId !== earliestId &&
+      group.latest?.value !== null &&
+      group.latest?.value !== undefined
+    ) {
+      entries.push({
+        id: latestId,
+        claim: {
+          value: group.latest.value,
+          country: refArea,
+          date: group.latest.year ?? undefined,
+        },
+      });
+    }
+  }
+  return entries;
+};
+
+/**
+ * Extractor for data360_get_data output.
+ * Extracts claim_id from standard data rows.
+ */
+export const getDataExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<{ data?: any[] }>(output);
+  if (!data?.data || !Array.isArray(data.data)) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const row of data.data) {
+    if (
+      row.claim_id &&
+      row.OBS_VALUE !== undefined &&
+      row.OBS_VALUE !== null
+    ) {
+      entries.push({
+        id: row.claim_id,
+        claim: {
+          value: row.OBS_VALUE,
+          country: row.REF_AREA,
+          date: row.TIME_PERIOD ? String(row.TIME_PERIOD) : undefined,
+        },
+      });
+    }
+  }
+  return entries;
+};

--- a/packages/data360/src/extractors.ts
+++ b/packages/data360/src/extractors.ts
@@ -79,7 +79,8 @@ export const compareCountriesExtractor: ToolResultExtractor = (output) => {
         if (!Array.isArray(pt)) continue;
         const claimId = colClaim >= 0 ? (pt[colClaim] as string | null) : null;
         const value = colValue >= 0 ? (pt[colValue] as number | null) : null;
-        const year = colYear >= 0 ? String(pt[colYear] ?? "") : undefined;
+        const rawYear = colYear >= 0 ? pt[colYear] : undefined;
+        const year = rawYear !== null && rawYear !== undefined && rawYear !== "" ? String(rawYear) : undefined;
         if (claimId && value !== null && value !== undefined) {
           entries.push({
             id: claimId,

--- a/packages/data360/src/index.ts
+++ b/packages/data360/src/index.ts
@@ -8,8 +8,28 @@ export type { Data360ClaimsProviderProps } from "./data360-claims-provider";
 export {
   IngestSessionData360,
   extractData360Outputs,
+  PreIngestSessionClaims,
+  claimsManager,
 } from "./ingest-session-data360";
 export type {
   IngestSessionData360Props,
-  MessageWithParts,
 } from "./ingest-session-data360";
+
+export {
+  rankCountriesExtractor,
+  compareCountriesExtractor,
+  summarizeDataExtractor,
+  getDataExtractor,
+} from "./extractors";
+
+export type {
+  CompactRankedCountry,
+  CompactRankingOutput,
+  CompactRankedEntry,
+  CompactComparisonSnapshot,
+  CompactTimeSeries,
+  CompactComparisonOutput,
+  CompactGroupSummary,
+  CompactSummaryOutput,
+  MessageWithParts,
+} from "./types";

--- a/packages/data360/src/ingest-session-data360.tsx
+++ b/packages/data360/src/ingest-session-data360.tsx
@@ -1,13 +1,43 @@
 "use client";
 
+import { ClaimsManager } from "@pcn-js/core";
 import { useClaimsManager } from "@pcn-js/ui";
-import { useEffect } from "react";
-import { DATA360_GET_DATA_TOOL } from "./data360-claims-provider";
+import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  compareCountriesExtractor,
+  rankCountriesExtractor,
+  summarizeDataExtractor,
+  getDataExtractor,
+} from "./extractors";
+import type { MessageWithParts } from "./types";
 
+// ---------------------------------------------------------------------------
+// Module-level singleton — extractors are registered synchronously at import
+// time, before any React render, so IngestToolOutput can always find them.
+// ---------------------------------------------------------------------------
+export const claimsManager = new ClaimsManager();
+claimsManager.registerExtractor("data360_rank_countries", rankCountriesExtractor);
+claimsManager.registerExtractor("data360_compare_countries", compareCountriesExtractor);
+claimsManager.registerExtractor("data360_summarize_data", summarizeDataExtractor);
+claimsManager.registerExtractor("data360_get_data", getDataExtractor);
+
+// Tool types we want to pre-ingest synchronously on load.
+const AGG_TOOL_TYPES = new Set([
+  "tool-data360_rank_countries",
+  "tool-data360_compare_countries",
+  "tool-data360_summarize_data",
+  "tool-data360_get_data",
+]);
+
+const AGG_TOOL_NAMES: Record<string, string> = {
+  "tool-data360_rank_countries": "data360_rank_countries",
+  "tool-data360_compare_countries": "data360_compare_countries",
+  "tool-data360_summarize_data": "data360_summarize_data",
+  "tool-data360_get_data": "data360_get_data",
+};
+
+const DATA360_GET_DATA_TOOL = "data360_get_data";
 const DATA360_TOOL_TYPE = "tool-data360_get_data" as const;
-
-/** Message shape: has optional parts array (AI SDK / data-thinking style). */
-export type MessageWithParts = { parts?: Array<Record<string, unknown>> };
 
 function isData360ToolPart(p: Record<string, unknown>): boolean {
   const type = p.type;
@@ -90,6 +120,70 @@ export function IngestSessionData360({
       manager.ingest(DATA360_GET_DATA_TOOL, output);
     }
   }, [messages, initialMessages, manager]);
+
+  return null;
+}
+
+/**
+ * Synchronously ingests all aggregation tool outputs from loaded messages
+ * during commit (via useLayoutEffect) so that ClaimMark can verify numbers on
+ * first paint — including after a page refresh when tool parts come from the DB.
+ *
+ * IngestToolOutput (from @pcn-js/ui) uses useEffect internally, which fires
+ * *after* first paint. This component closes that gap by calling
+ * claimsManager.ingest() during the commit phase for any session data that is
+ * already present when the component mounts.
+ */
+export function PreIngestSessionClaims({
+  messages,
+  initialMessages = [],
+}: {
+  messages: MessageWithParts[];
+  initialMessages?: MessageWithParts[];
+}) {
+  const ingestedPartKeysRef = useRef(new Set<string>());
+
+  useLayoutEffect(() => {
+    const buildPartKey = (part: Record<string, unknown>, toolName: string) => {
+      if (typeof part.id === "string") return `${toolName}:${part.id}`;
+      const toolCallId = typeof part.toolCallId === "string" ? part.toolCallId : "";
+      return `${toolName}:${toolCallId}:${JSON.stringify(part.output ?? null)}`;
+    };
+
+    const source = messages.length > 0 ? messages : initialMessages;
+    for (const msg of source) {
+      for (const part of msg.parts ?? []) {
+        const type = part.type as string | undefined;
+        if (!type) continue;
+
+        // Top-level tool parts
+        if (AGG_TOOL_TYPES.has(type) && part.state === "output-available" && part.output != null) {
+          const toolName = AGG_TOOL_NAMES[type];
+          if (toolName) {
+            const partKey = buildPartKey(part, toolName);
+            if (ingestedPartKeysRef.current.has(partKey)) continue;
+            claimsManager.ingest(toolName, part.output);
+            ingestedPartKeysRef.current.add(partKey);
+          }
+        }
+
+        // data-thinking-wrapped tool parts
+        if (type === "data-thinking" && part.data != null && typeof part.data === "object") {
+          const inner = part.data as Record<string, unknown>;
+          const innerType = inner.type as string | undefined;
+          if (innerType && AGG_TOOL_TYPES.has(innerType) && inner.state === "output-available" && inner.output != null) {
+            const toolName = AGG_TOOL_NAMES[innerType];
+            if (toolName) {
+              const partKey = buildPartKey(inner, toolName);
+              if (ingestedPartKeysRef.current.has(partKey)) continue;
+              claimsManager.ingest(toolName, inner.output);
+              ingestedPartKeysRef.current.add(partKey);
+            }
+          }
+        }
+      }
+    }
+  }, [messages, initialMessages]);
 
   return null;
 }

--- a/packages/data360/src/ingest-session-data360.tsx
+++ b/packages/data360/src/ingest-session-data360.tsx
@@ -9,17 +9,25 @@ import {
   summarizeDataExtractor,
   getDataExtractor,
 } from "./extractors";
-import type { MessageWithParts } from "./types";
+import { DATA360_GET_DATA_TOOL, type MessageWithParts } from "./types";
+
+/**
+ * Creates a new ClaimsManager instance with all Data360 extractors pre-registered.
+ */
+export function createData360ClaimsManager(): ClaimsManager {
+  const manager = new ClaimsManager();
+  manager.registerExtractor("data360_rank_countries", rankCountriesExtractor);
+  manager.registerExtractor("data360_compare_countries", compareCountriesExtractor);
+  manager.registerExtractor("data360_summarize_data", summarizeDataExtractor);
+  manager.registerExtractor("data360_get_data", getDataExtractor);
+  return manager;
+}
 
 // ---------------------------------------------------------------------------
 // Module-level singleton — extractors are registered synchronously at import
 // time, before any React render, so IngestToolOutput can always find them.
 // ---------------------------------------------------------------------------
-export const claimsManager = new ClaimsManager();
-claimsManager.registerExtractor("data360_rank_countries", rankCountriesExtractor);
-claimsManager.registerExtractor("data360_compare_countries", compareCountriesExtractor);
-claimsManager.registerExtractor("data360_summarize_data", summarizeDataExtractor);
-claimsManager.registerExtractor("data360_get_data", getDataExtractor);
+export const claimsManager = createData360ClaimsManager();
 
 // Tool types we want to pre-ingest synchronously on load.
 const AGG_TOOL_TYPES = new Set([
@@ -36,7 +44,6 @@ const AGG_TOOL_NAMES: Record<string, string> = {
   "tool-data360_get_data": "data360_get_data",
 };
 
-const DATA360_GET_DATA_TOOL = "data360_get_data";
 const DATA360_TOOL_TYPE = "tool-data360_get_data" as const;
 
 function isData360ToolPart(p: Record<string, unknown>): boolean {
@@ -137,17 +144,27 @@ export function IngestSessionData360({
 export function PreIngestSessionClaims({
   messages,
   initialMessages = [],
+  manager: customManager,
 }: {
   messages: MessageWithParts[];
   initialMessages?: MessageWithParts[];
+  manager?: ClaimsManager;
 }) {
+  const contextManager = useClaimsManager();
+  const manager = customManager ?? contextManager ?? claimsManager;
   const ingestedPartKeysRef = useRef(new Set<string>());
 
   useLayoutEffect(() => {
+    if (!manager) return;
+
     const buildPartKey = (part: Record<string, unknown>, toolName: string) => {
       if (typeof part.id === "string") return `${toolName}:${part.id}`;
       const toolCallId = typeof part.toolCallId === "string" ? part.toolCallId : "";
-      return `${toolName}:${toolCallId}:${JSON.stringify(part.output ?? null)}`;
+      try {
+        return `${toolName}:${toolCallId}:${JSON.stringify(part.output ?? null)}`;
+      } catch {
+        return `${toolName}:${toolCallId}:error`;
+      }
     };
 
     const source = messages.length > 0 ? messages : initialMessages;
@@ -162,7 +179,7 @@ export function PreIngestSessionClaims({
           if (toolName) {
             const partKey = buildPartKey(part, toolName);
             if (ingestedPartKeysRef.current.has(partKey)) continue;
-            claimsManager.ingest(toolName, part.output);
+            manager.ingest(toolName, part.output);
             ingestedPartKeysRef.current.add(partKey);
           }
         }
@@ -176,14 +193,14 @@ export function PreIngestSessionClaims({
             if (toolName) {
               const partKey = buildPartKey(inner, toolName);
               if (ingestedPartKeysRef.current.has(partKey)) continue;
-              claimsManager.ingest(toolName, inner.output);
+              manager.ingest(toolName, inner.output);
               ingestedPartKeysRef.current.add(partKey);
             }
           }
         }
       }
     }
-  }, [messages, initialMessages]);
+  }, [messages, initialMessages, manager]);
 
   return null;
 }

--- a/packages/data360/src/types.ts
+++ b/packages/data360/src/types.ts
@@ -19,13 +19,9 @@ export type CompactRankingOutput = {
   error: string | null;
 };
 
-export type CompactRankedEntry = {
-  rank?: number;
-  code?: string;
-  country?: string;
-  value?: number;
-  claim_id?: string | null;
-};
+export type CompactRankedEntry = CompactRankedCountry;
+
+export const DATA360_GET_DATA_TOOL = "data360_get_data";
 
 export type CompactComparisonSnapshot = {
   year?: string;

--- a/packages/data360/src/types.ts
+++ b/packages/data360/src/types.ts
@@ -1,0 +1,81 @@
+export type CompactRankedCountry = {
+  rank?: number;
+  code?: string;
+  country?: string;
+  value?: number;
+  claim_id?: string | null;
+};
+
+export type CompactRankingOutput = {
+  year: string | null;
+  year_selection_note: string | null;
+  order: "asc" | "desc";
+  counts: { with_data: number; requested: number };
+  unit: string | null;
+  indicator: string | null;
+  rankings: CompactRankedCountry[];
+  excluded_count: number;
+  excluded_sample: Array<{ code: string; name: string | null }>;
+  error: string | null;
+};
+
+export type CompactRankedEntry = {
+  rank?: number;
+  code?: string;
+  country?: string;
+  value?: number;
+  claim_id?: string | null;
+};
+
+export type CompactComparisonSnapshot = {
+  year?: string;
+  rankings?: CompactRankedEntry[];
+  spread?: Record<string, number | null>;
+};
+
+export type CompactTimeSeries = {
+  year_range?: string | null;
+  n_aligned_years?: number;
+  convergence?: string | null;
+  cagr?: Record<string, number | null>;
+  series_schema?: string[];
+  series?: Record<string, [string, number, string | null][]>;
+};
+
+export type CompactComparisonOutput = {
+  indicator?: string | null;
+  unit?: string | null;
+  snapshot?: CompactComparisonSnapshot | null;
+  time_series?: CompactTimeSeries | null;
+  error?: string | null;
+  [key: string]: unknown;
+};
+
+export type CompactGroupSummary = {
+  group: Record<string, string>;
+  n: number;
+  latest: { value: number | null; year: string | null };
+  earliest: { value: number | null; year: string | null };
+  range: string | null;
+  stats: {
+    min: number | null;
+    max: number | null;
+    mean: number | null;
+    median: number | null;
+  };
+  change: { abs: number | null; pct: number | null };
+  trend: string | null;
+  claim_ids: string[];
+};
+
+export type CompactSummaryOutput = {
+  indicator: string | null;
+  unit: string | null;
+  ambiguous_dimensions: string[] | null;
+  groups: CompactGroupSummary[];
+  error: string | null;
+};
+
+export type MessageWithParts = {
+  parts?: Array<Record<string, unknown>>;
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
     "react": "^18.3.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,10 +115,16 @@ importers:
       '@pcn-js/core':
         specifier: workspace:*
         version: link:../core
+      react-dom:
+        specifier: '>=18.0.0'
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.27)
       react:
         specifier: ^18.3.0
         version: 18.3.1


### PR DESCRIPTION
Migrates custom claim extractors, compact type definitions, and PreIngestSessionClaims from data-ai-chatbot to @pcn-js/data360 package.

### Release Status
- `@pcn-js/data360` has been successfully versioned, built, and published to the npm registry at version `0.1.3` (along with dependencies updated under the changeset release flow).
