### PR TITLE
chore(release): version packages and bump to 0.1.4

### DIFF
--- a/examples/chat-app/CHANGELOG.md
+++ b/examples/chat-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pcn-example-chat-app
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcn-js/data360@0.1.4
+
 ## 0.0.4
 
 ### Patch Changes
@@ -16,7 +23,6 @@
   - @pcn-js/core@0.1.2
   - @pcn-js/data360@0.1.2
   - @pcn-js/ui@0.1.2
-
 
 ## 0.0.2
 

--- a/examples/chat-app/package.json
+++ b/examples/chat-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcn-example-chat-app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/data360/CHANGELOG.md
+++ b/packages/data360/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pcn-js/data360
 
+## 0.1.4
+
+### Patch Changes
+
+- Fix custom claim extractors and type definitions.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/data360/package.json
+++ b/packages/data360/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcn-js/data360",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "PCN preset for Data360 get_data: ClaimsProvider + extractor for claim_id/OBS_VALUE/REF_AREA/TIME_PERIOD.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bumps package versions and updates changelogs for the v0.1.4 release of @pcn-js/data360.